### PR TITLE
proper interaction display false

### DIFF
--- a/src/components/contractinteraction/index.js
+++ b/src/components/contractinteraction/index.js
@@ -157,7 +157,8 @@ var render=function(abi, contract) {
                     var id2=id+"_output_"+index;
                     var val=res.shift()
                     var isBool = typeof val =='boolean'
-                    var value=val || isBool?val:iserr?"(ERROR)":"(NO DATA)";
+                    var isString = typeof val =='string'
+                    var value=val || isBool?val:isString?"(Empty)":iserr?"(ERROR)":"(NO DATA)";
                     if(item.type=="uint256") {
                         value=res.toNumber();
                     }

--- a/src/components/contractinteraction/index.js
+++ b/src/components/contractinteraction/index.js
@@ -155,7 +155,9 @@ var render=function(abi, contract) {
                 for(var index=0;index<item.outputs.length;index++) {
                     var output=item.outputs[index];
                     var id2=id+"_output_"+index;
-                    var value=res.shift() || (iserr?"(ERROR)":"(NO DATA)");
+                    var val=res.shift()
+                    var isBool = typeof val =='boolean'
+                    var value=val || isBool?val:iserr?"(ERROR)":"(NO DATA)";
                     if(item.type=="uint256") {
                         value=res.toNumber();
                     }


### PR DESCRIPTION
When interacting with a contract, a boolean value of `false` displays as `(No Data)` which is does not accurately reflect the contract state.  I left the `(No Data)` message for type string, but maybe `(Empty)` would be better there.

```solidity
pragma solidity ^0.4.17;

contract Values {
  function getFalsey() constant public returns(string, uint, bool){
      return ("", 0, false); // (No Data), 0, false -- currently returns (No Data) instead of false
  }
  
  function getTruthy() constant public returns(string, uint, bool){
      return ("yes", 100, true); // as expected
  }  
}
```