### PR TITLE
Added Github issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,15 +1,27 @@
-### Environment/Browser
+---
+name: Bug report
+about: Create a report to help us improve
+---
 
-### Description
+<!-- Please search existing issues to avoid creating duplicates. -->
+<!-- Also please test using the latest beta version to make sure your issue has not already been fixed: https://studio-beta.superblocks.com/ -->
 
-### Steps to reproduce
+## Environment/Browser
+Simply tell which browser and version are you using
+
+## Description
+Concise and descriptive message explaining what the issue is
+
+## Steps to reproduce
 1.
 2.
 3.
 
-### Expected result
+## Expected result
+Describe what are you actually expecting to happen
 
-### Actual result
+## Actual result
+Describe what is it actually happening in your case
 
-### Reproducible
-100%
+## Reproducible
+Describe how many times (in %) is the bug appearing (ex. 100%)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ about: Create a report to help us improve
 <!-- Also please test using the latest beta version to make sure your issue has not already been fixed: https://studio-beta.superblocks.com/ -->
 
 ## Environment/Browser
-Simply tell which browser and version are you using
+Simply tell which browser and version of it you are using
 
 ## Description
 Concise and descriptive message explaining what the issue is
@@ -21,7 +21,7 @@ Concise and descriptive message explaining what the issue is
 Describe what are you actually expecting to happen
 
 ## Actual result
-Describe what is it actually happening in your case
+Describe what is actually happening in your case
 
 ## Reproducible
-Describe how many times (in %) is the bug appearing (ex. 100%)
+Describe aproximately how many times (in %) is the bug appearing (ex. 100%)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,4 +24,4 @@ Describe what are you actually expecting to happen
 Describe what is actually happening in your case
 
 ## Reproducible
-Describe aproximately how many times (in %) is the bug appearing (ex. 100%)
+Describe approximately how many times (in %) is the bug appearing (ex. 100%)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+### Environment/Browser
+
+### Description
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected result
+
+### Actual result
+
+### Reproducible
+100%

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+<!--
+
+Have you read Superblock Studios's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/superblocksHQ/studio/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Superblocks community is the best place for getting support: https://t.me/GetSuperblocks
+
+
+-->
+
+## Summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Describe alternatives you've considered
+
+A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest an idea for this project
 
 <!--
 
-Have you read Superblock Studios's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/superblocksHQ/studio/blob/master/CODE_OF_CONDUCT.md
+Have you read Superblocks Studios's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/superblocksHQ/studio/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Superblocks community is the best place for getting support: https://t.me/GetSuperblocks
 
@@ -21,6 +21,6 @@ Why are we doing this? What use cases does it support? What is the expected outc
 
 ## Describe alternatives you've considered
 
-A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
+A clear and concise description of the alternative solutions you've considered.
 
 ## Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,6 @@ Have you read Superblock Studios's Code of Conduct? By filing an Issue, you are 
 
 Do you want to ask a question? Are you looking for support? The Superblocks community is the best place for getting support: https://t.me/GetSuperblocks
 
-
 -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: The issue tracker is not for questions. Please ask questions on https://stackoverflow.com/questions/tagged/superblocks.
+---
+
+🚨 The issue tracker is not for questions 🚨
+
+If you have a question, please ask it on https://stackoverflow.com/questions/tagged/superblocks.


### PR DESCRIPTION
Added Github issues templates to the project in order to make sure all our issues in the projects are well documented.

There are 3 new types of templates:
- Bug reports: Used to simply report any new bugs found in the Studio
- New Feature: Propose a new feature to be developed
- Question: Redirect user to StackOverflow to make sure questions are actually asked there so we can keep the project issues relevant to the code itself. 