### PR TITLE
Add single dapp project import and export

### DIFF
--- a/src/components/newdapp/index.js
+++ b/src/components/newdapp/index.js
@@ -37,7 +37,7 @@ export default class DevkitNewDapp extends Component {
         if(evt) evt.preventDefault();
         var title=this.state.projectTitle;
         if(dappfileJSONObj) {
-            // We assume it's validity is checked already.
+            // We assume its validity is checked already.
             title=dappfileJSONObj.dappfile.project.info.title;
         }
         var project=this.state.projectName;
@@ -101,57 +101,47 @@ export default class DevkitNewDapp extends Component {
         }
     };
 
-    import = (evt) => {
-        evt.preventDefault();
+    _clickProject = (e) => {
+        e.preventDefault();
+        document.querySelector('#wsProjectFileInput').dispatchEvent(new MouseEvent('click')); // ref does not work https://github.com/developit/preact/issues/477
+    }
+
+    _uploadProject = (e) => {
+        e.preventDefault();
         var project=this.state.projectName;
         if(project=="") {
             alert("Please give the project a name.");
+            document.querySelector('#wsProjectFileInput').value = "";
             return;
         }
         if(!project.match(/^([a-zA-Z0-9-]+)$/)) {
             alert('Illegal projectname. Only A-Za-z0-9 and dash (-) allowed.');
+            document.querySelector('#wsProjectFileInput').value = "";
             return;
         }
         var contentJSON="";
-        const ok=(e)=>{
-            e.preventDefault();
-            if(!contentJSON) {
-                alert("No JSON provided. Paste it into the text area and try again.");
-                return;
+
+        var files = document.querySelector('#wsProjectFileInput').files;
+        var file = files[0];
+
+        const handler=(status, code) => {
+            if(this.props.cb) {
+                const index=this.props.functions.modal.getCurrentIndex();
+                if(this.props.cb(status, code) !== false) this.props.functions.modal.close(index);
             }
-            var dappfileJSONObj;
-            try {
-                dappfileJSONObj=JSON.parse(contentJSON);
+            else {
+                this.props.functions.modal.close();
             }
-            catch(e) {
-                alert("Could not parse JSON, is it properly pasted?");
-                return;
+        };
+
+        this.props.backend.uploadProject(project, file, handler, err => {
+            if(err) {
+                alert(err);
             }
-            console.log("import", dappfileJSONObj);
-            // TODO: FIXME: validate the object.
-            this.add(null, dappfileJSONObj);
             this.props.functions.modal.close();
-        };
-        const handleContentChange=(e)=> {
-            contentJSON=e.target.value;
-        };
-        const body=(
-            <div>
-                <p>Paste your DAppfile.json contents below and press 'Import'.</p>
-                <div><textarea id="dappfilejsonimport" name="" onChange={handleContentChange} style="width:100%;height:200px;"></textarea></div>
-                <div style="margin-top: 10px;">
-                    <a class="btn2" style="float: left; margin-right: 30px;" onClick={this.props.functions.modal.cancel}>Cancel</a>
-                    <a class="btn2 filled" style="float: left;" onClick={ok}>Import</a>
-                </div>
-            </div>
-        );
-        const modalData={
-            title: "Import DAppfile.json",
-            body: body,
-            style: {"text-align":"center",height:"400px"},
-        };
-        const modal=(<Modal data={modalData} />);
-        this.props.functions.modal.show({render: () => {return modal;}});
+        });
+
+        e.target.value = '';
     }
 
     handleNameChange = changeEvent => {
@@ -190,7 +180,8 @@ export default class DevkitNewDapp extends Component {
                 <div class={style.footer}>
                     <a onClick={this.props.functions.modal.cancel} class="btn2" style="float: left; margin-right: 30px;" href="#">Cancel</a>
                     <a onClick={this.add} class="btn2 filled" style="float: left;"  href="#">Create</a>
-                    <a onClick={this.import} class="" style="float: right;margin-top: 20px;margin-right: 10px;" href="#">Import DAppfile.json...</a>
+                    <a onClick={ e => this._clickProject(e)} class="" style="float: right;margin-top: 20px;margin-right: 10px;" href="#">Import Dapp from existing JSON file...</a>
+                    <input id="wsProjectFileInput" type="file" style="display: none;" onChange={e => this._uploadProject(e)} ref={w => this.wsProjectFileInput=w} />
                 </div>
                 <div class={style.area}>
                     <div class={style.form}>

--- a/src/components/projecteditor/backend.js
+++ b/src/components/projecteditor/backend.js
@@ -286,6 +286,29 @@ export default class Backend {
         downloadAnchorNode.remove();
     }
 
+    downloadProject = (projectName) => {
+        const exportName = "superblocks_project_" + projectName;
+        const workspace = JSON.parse(localStorage.getItem("dapps1.0")) || {};
+        var project = workspace.projects.filter((item) => {
+            return item.dir==projectName;
+        })[0];
+
+        // Return on empty project
+        if(Object.keys(project).length <= 0) {
+            console.warn("Unable to locate project: " + projectName);
+            return;
+        }
+
+        var exportObj = project;
+        var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj));
+        var downloadAnchorNode = document.createElement('a');
+        downloadAnchorNode.setAttribute("href",     dataStr);
+        downloadAnchorNode.setAttribute("download", exportName + ".json");
+        document.body.appendChild(downloadAnchorNode); // required for firefox
+        downloadAnchorNode.click();
+        downloadAnchorNode.remove();
+    }
+
     uploadWorkspace = (file, cb) => {
         var reader = new FileReader();
       
@@ -310,6 +333,29 @@ export default class Backend {
         reader.readAsBinaryString(blob);
     }
 
+    uploadProject = (project, file, handler, cb) => {
+        var reader = new FileReader();
 
+        reader.onloadend = (evt) => {
+            var dappfileJSONObj;
+            if (evt.target.readyState == FileReader.DONE) {
+                try {
+                    const obj = JSON.parse(evt.target.result);
+                    if (!obj.dir) {
+                        cb('invalid project file');
+                        return;
+                    }
+                    dappfileJSONObj = obj;
+                } catch (e) {
+                    cb('invalid JSON');
+                    return;
+                }
+                this.saveProject(project, {dappfile:dappfileJSONObj.dappfile}, (o)=>{handler(o.status,o.code)}, true, dappfileJSONObj.files)
+                cb();
+            }
+        };
 
+        var blob = file.slice(0, file.size);
+        reader.readAsBinaryString(blob);
+    }
 }

--- a/src/components/projecteditor/control.js
+++ b/src/components/projecteditor/control.js
@@ -473,7 +473,7 @@ export default class DevkitProjectEditorControl extends Component {
                 });
             }
             else {
-                alert("A DApp with that name already exists, chose a different name.");
+                alert("A DApp with that name already exists, choose a different name.");
             }
         };
         const cancel=(modal) =>{

--- a/src/components/projecteditor/editor-app.js
+++ b/src/components/projecteditor/editor-app.js
@@ -17,6 +17,8 @@
 import { h, Component } from 'preact';
 import classnames from 'classnames';
 import style from './style-editor-contract';
+import Backend from  './backend';
+
 import FaIcon  from '@fortawesome/react-fontawesome';
 import iconSave from '@fortawesome/fontawesome-free-regular/faSave';
 import iconCompile from '@fortawesome/fontawesome-free-solid/faPuzzlePiece';
@@ -27,6 +29,7 @@ import iconDebug from '@fortawesome/fontawesome-free-solid/faBug';
 export default class AppEditor extends Component {
     constructor(props) {
         super(props);
+        this.backend = new Backend();
         this.id=props.id+"_editor";
         this.props.parent.childComponent=this;
         this.dappfile = this.props.project.props.state.data.dappfile;
@@ -117,7 +120,6 @@ export default class AppEditor extends Component {
             }
         };
         clearDotfiles(dappfilejson.files);
-        const dappfileexport=JSON.stringify(dappfilejson);
 
         const toolbar=this.renderToolbar();
         const maxHeight = {
@@ -139,8 +141,7 @@ export default class AppEditor extends Component {
                     </form>
                 </div>
             <div>
-                <a href="#" onClick={(e)=>{e.preventDefault();this.setState({show:true});}}>Show Dappfile.json for export</a>
-                {this.state.show && <textarea style="width:100%;height:300px;" readonly="true">{dappfileexport}</textarea>}
+                <a href="#" onClick={(e)=>{e.preventDefault();this.backend.downloadProject(this.props.dappfilejson.dir);}}>Export Dapp as a JSON file</a>
             </div>
             </div>
         </div>);


### PR DESCRIPTION
Based on #20 and the latest download and upload workspace addition (64e4455), this feature enables downloading a project as a file and uploading it back as a new dapp.

For a given project, in the _Edit DApp Configuration_ window (settings), click the _Export_ link to download the dapp project as a _JSON_ file.
For importing, create a _New Dapp_, enter the project name and click the link at the bottom right of the modal. 